### PR TITLE
#167186527 Endpoint for Showing Properties by type

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -17,6 +17,7 @@
     "rules": {
         "linebreak-style": 0,
         "no-trailing-spaces": 0,
-        "lines-between-class-members": 0
+        "lines-between-class-members": 0,
+        "no-lonely-if":"off"
     }
 }

--- a/server/controller/propertyController.js
+++ b/server/controller/propertyController.js
@@ -87,10 +87,33 @@ class property {
     }
   }
   static viewAllProperties(req, res) {
-    res.json({
-      status: 200,
-      data: Property,
-    });
+    if (req.query.type) {
+      const { type } = req.query;
+      const typeProperties = Property.filter(theProperties => theProperties.type === type);
+      if (!typeProperties) {
+        res.json({
+          status: 400,
+          error: 'No properties matching the entered type',
+        });
+      } else {
+        res.json({
+          status: 200,
+          data: typeProperties,
+        });
+      }
+    } else {
+      if (Property.length === 0) {
+        res.json({
+          status: 400,
+          error: 'No properties to show',
+        });
+      } else {
+        res.json({
+          status: 200,
+          data: Property,
+        });
+      }
+    }
   }
   static updateProperty(req, res) {
     const id = parseInt(req.params.id, 10);


### PR DESCRIPTION
**What does this PR do?**

Adds a View all Properties by Type Endpoint

**Description of Task to be completed?**

Adds an endpoint that allows the user to view all the properties matching a given type

**How should this be manually tested?**

Clone the repository and `run npm install` to install the dependencies. Then head to postman and send a `get` request to `localhost:5000/api/v1/property/?type=<propertyType>` to view all properties matching the type

**What are the relevant pivotal tracker stories?**

#167186527 