### PR TITLE
#167340913 User (Agent) Can mark a property as Sold

### DIFF
--- a/server/controller/propertyController.js
+++ b/server/controller/propertyController.js
@@ -173,6 +173,47 @@ class property {
     }
   }
 
+  static async markAsSold(req, res) {
+    const id = parseInt(req.params.id, 10);
+    const propertyInfo = await schema.getProperty([id]);
+    if (!propertyInfo) {
+      res.status(404).json({
+        status: 404,
+        error: 'Property not found',
+      });
+    } else {
+      if (propertyInfo.owner !== req.user.id) {
+        res.status(403).json({
+          status: 403,
+          error: 'You can not edit this property',
+        });
+      } else {
+        const theProperty = await schema.markAsSold([id]);
+        if (theProperty) {
+          res.status(202).json({
+            status: 202,
+            data: {
+              id: theProperty.id,
+              status: theProperty.status,
+              type: theProperty.type,
+              state: theProperty.state,
+              city: theProperty.city,
+              address: theProperty.address,
+              price: theProperty.price,
+              created_on: theProperty.createdOn,
+              image_url: theProperty.image_url,
+            },
+          });
+        } else {
+          res.status(500).json({
+            status: 500,
+            error: 'Error deleteing the property',
+          });
+        }
+      }
+    }
+  }
+
   static async viewSpecificProperty(req, res) {
     const id = parseInt(req.params.id, 10);
     const propertyInfo = await schema.getProperty([id], req.user.isAdmin);

--- a/server/routes/propertyRoute.js
+++ b/server/routes/propertyRoute.js
@@ -13,7 +13,7 @@ router.post('/', validation.propertyValidation, propertyController.addProperty);
 // router.delete('/:id', propertyController.deleteProperty);
 router.get('/:id', propertyController.viewSpecificProperty);
 // router.get('/', propertyController.viewAllProperties);
-// router.patch('/:id/sold', propertyController.markAsSold);
+router.patch('/:id/sold', propertyController.markAsSold);
 router.patch('/:id', validation.updateValidation, propertyController.updateProperty);
 
 export default router;


### PR DESCRIPTION
#### What does this PR do?
Allows the agent to update the property as Sold
#### Description of Task to be completed?
Allows the agent to update his/her property that is Sold so that it is not shown to users in the DB
#### How should this be manually tested?
Clone this repo to your computer and run `npm install` to install all dependencies then send a PATCH request to `/property/<:id>/sold`
#### Any background context you want to provide?
>- Wrote the endpoint that sends the ID to the schema that update the property info to sold
>- Also checks if the person sending the request is the owner of the property advert.
#### What are the relevant pivotal tracker stories?
#167340913
#### Screenshots (if appropriate)
![96](https://user-images.githubusercontent.com/50402526/61394283-0c4d6a80-a8c3-11e9-95b3-0dc8213e7d44.PNG)

#### Questions: